### PR TITLE
Proper checks for systemd capable OS

### DIFF
--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -10,7 +10,12 @@ upstart = true
 init_provider = Chef::Provider::Service::Upstart
 
 if node[:init_package] == 'init'
-  init_provider = Chef::Provider::Service::Init
+  case node[:platform_family]
+  when "rhel"
+    init_provider = Chef::Provider::Service::Init::Redhat
+  when "debian"
+    init_provider = Chef::Provider::Service::Init::Debian
+  end
   init = true
   upstart = false
 end

--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -3,20 +3,20 @@
 #
 #
 
-## handle rhel7/debian
+## Handle Upstart/Init/Systemd properly
 systemd = false
 init = false
 upstart = true
 init_provider = Chef::Provider::Service::Upstart
 
-if node[:platform_family] == 'rhel' && node[:platform_version].to_i >= 7
-  systemd = true
-  upstart = false
-  init_provider = Chef::Provider::Service::Systemd
-end
-if node[:platform] == 'debian'
-  init_provider = Chef::Provider::Service::Init::Debian
+if node[:init_package] == 'init'
+  init_provider = Chef::Provider::Service::Init
   init = true
+  upstart = false
+end
+if node[:init_package] == 'systemd'
+  init_provider = Chef::Provider::Service::Systemd
+  systemd = true
   upstart = false
 end
 


### PR DESCRIPTION
The old checks leave modern operating systems with failing Init-V style scripts instead of using Systemd compatible scripts. This should just simply check which style of init system is being used and do the right thing instead of checking for OS versions and such.