### PR TITLE
Change wait ready command for systemd from etcd to etcdctl

### DIFF
--- a/libraries/etcd_service_manager_systemd.rb
+++ b/libraries/etcd_service_manager_systemd.rb
@@ -46,7 +46,7 @@ module EtcdCookbook
         owner 'root'
         group 'root'
         mode '0755'
-        variables(etcd_cmd: etcd_cmd)
+        variables(etcdctl_cmd: etcdctl_cmd)
         cookbook 'etcd'
         action :create
       end

--- a/templates/default/systemd/etcd-wait-ready.erb
+++ b/templates/default/systemd/etcd-wait-ready.erb
@@ -2,7 +2,7 @@
 i=0
 while [ $i -lt 40 ]; do
   ((i++))
-  <%= @etcd_cmd %> cluster-health
+  <%= @etcdctl_cmd %> cluster-health
   [ $? -eq 0 ] && break
   sleep 0.5
 done


### PR DESCRIPTION
etcd-wait-ready script for systemd is executing etcd instead of etcdctl to check cluster health.
This PR changes etcd_cmd to etcdctl_cmd in
 - templates/default/systemd/etcd-wait-ready.erb
 - libraries/etcd_service_manager_systemd (template variables)

Only tested under Ubuntu 15.04.