### PR TITLE
docker_service_manager replaced by etcd_service_manager

### DIFF
--- a/libraries/etcd_service_manager_execute.rb
+++ b/libraries/etcd_service_manager_execute.rb
@@ -1,7 +1,7 @@
 module EtcdCookbook
   class EtcdServiceManagerExecute < EtcdServiceBase
     resource_name :etcd_service_manager_execute
-    provides :docker_service_manager, os: 'linux'
+    provides :etcd_service_manager, os: 'linux'
 
     # Start the service
     action :start do

--- a/libraries/etcd_service_manager_systemd.rb
+++ b/libraries/etcd_service_manager_systemd.rb
@@ -1,17 +1,17 @@
 module EtcdCookbook
   class EtcdServiceManagerSystemd < EtcdServiceBase
     resource_name :etcd_service_manager_systemd
-    provides :docker_service_manager, platform: 'fedora'
+    provides :etcd_service_manager, platform: 'fedora'
 
-    provides :docker_service_manager, platform: %w(redhat centos scientific) do |node| # ~FC005
+    provides :etcd_service_manager, platform: %w(redhat centos scientific) do |node| # ~FC005
       node['platform_version'].to_f >= 7.0
     end
 
-    provides :docker_service_manager, platform: 'debian' do |node|
+    provides :etcd_service_manager, platform: 'debian' do |node|
       node['platform_version'].to_f >= 8.0
     end
 
-    provides :docker_service_manager, platform: 'ubuntu' do |node|
+    provides :etcd_service_manager, platform: 'ubuntu' do |node|
       node['platform_version'].to_f >= 15.04
     end
 


### PR DESCRIPTION
Using `etcd_service_manager_systemd` works right, but when using dynamic provider resolution the `provides` label in 'etcd_service_manager' is assigned `docker_service_manager` resource name.

Affected files: 
 - libraries/etcd_service_manager_execute.rb
 - libraries/etcd_service_manager_systemd.rb

This fix has only been checked for Ubuntu 15.04.
 
