### PR TITLE
wait-ready systemd. Enhance/fix timeout pattern

### DIFF
--- a/libraries/etcd_service_manager_systemd.rb
+++ b/libraries/etcd_service_manager_systemd.rb
@@ -15,6 +15,8 @@ module EtcdCookbook
       node['platform_version'].to_f >= 15.04
     end
 
+    property :service_timeout, Integer, default: 20
+
     action :start do
       user 'etcd' do
         action :create
@@ -46,7 +48,10 @@ module EtcdCookbook
         owner 'root'
         group 'root'
         mode '0755'
-        variables(etcdctl_cmd: etcdctl_cmd)
+        variables(
+          etcdctl_cmd: etcdctl_cmd,
+          service_timeout: service_timeout
+        )
         cookbook 'etcd'
         action :create
       end

--- a/templates/default/systemd/etcd-wait-ready.erb
+++ b/templates/default/systemd/etcd-wait-ready.erb
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 i=0
-while [ $i -lt 40 ]; do
-  ((i++))
-  <%= @etcdctl_cmd %> cluster-health
+while [ $i -lt <%= @service_timeout * 2 %> ]; do
+  <%= @etcdctl_cmd %> cluster-health > /dev/null 2>&1
   [ $? -eq 0 ] && break
+  ((i++))
   sleep 0.5
 done
-[ $i -eq 20 ] && exit 1
+[ $i -eq <%= @service_timeout * 2 %> ] && exit 1
 exit 0


### PR DESCRIPTION

wait-ready failure check was checking a different number thant the maximum number of tries.

iteration counter was being added before break statement, so if the last iteration was successful, the script would return failure.

also added service_timeout as parameter.