### PR TITLE
Fix bug at wait-ready-script

### DIFF
--- a/templates/default/systemd/etcd-wait-ready.erb
+++ b/templates/default/systemd/etcd-wait-ready.erb
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 i=0
 while [ $i -lt <%= @service_timeout * 2 %> ]; do
+  ((i++))
   <%= @etcdctl_cmd %> cluster-health > /dev/null 2>&1
   [ $? -eq 0 ] && break
-  ((i++))
   sleep 0.5
 done
 [ $i -eq <%= @service_timeout * 2 %> ] && exit 1


### PR DESCRIPTION
My last PR 720d21c6df83b85d8f038eee50469daf20b2ab03 introduced a bug.
Iteration goes from 0 to number, so it's ok to have the iterator addition at the beginning of the loop, and checking for number at the end.
Sorry for that!